### PR TITLE
Fix badge and popup count synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ There are no extension-owned analytics, telemetry endpoints, remote logs, or bun
 5. Select the GetBlocked! project folder.
 6. Pin GetBlocked! and open the popup on normal web pages.
 
-The production build avoids debug-only DNR feedback permissions. The popup uses local page signals plus Chrome's production DNR action-count badge as a page-level estimate. In normal mode, blocking and URL cleanup are enforced by MV3 `declarativeNetRequest`; in Decoy Mode, only the blocking rule is disabled.
+The production build avoids debug-only DNR feedback permissions. The popup uses local page signals for a page-level estimate, and the extension badge mirrors **Blocked on this page** in normal mode or **Decoyed on this page** in Decoy Mode. URL-cleaning activity is reported separately. In normal mode, blocking and URL cleanup are enforced by MV3 `declarativeNetRequest`; in Decoy Mode, only the blocking rule is disabled.
 
 ## Contribute In 10 Minutes
 

--- a/background.js
+++ b/background.js
@@ -93,25 +93,25 @@ function updateStaticRules(options) {
   return chrome.declarativeNetRequest.updateStaticRules(options);
 }
 
-function getBadgeText(tabId) {
+function setBadgeText(tabId, text) {
   return new Promise((resolve) => {
     if (!Number.isInteger(tabId) || tabId < 0) {
-      resolve("");
+      resolve();
       return;
     }
 
-    chrome.action.getBadgeText({ tabId }, (badgeText) => {
-      const error = chrome.runtime.lastError;
-      resolve(error ? "" : badgeText || "");
+    chrome.action.setBadgeText({ tabId, text }, () => {
+      void chrome.runtime.lastError;
+      resolve();
     });
   });
 }
 
-function setDnrActionBadgeEnabled() {
+function configureActionBadge() {
   chrome.action.setBadgeBackgroundColor({ color: "#0f766e" });
 
   chrome.declarativeNetRequest.setExtensionActionOptions(
-    { displayActionCountAsBadgeText: true },
+    { displayActionCountAsBadgeText: false },
     () => {
       void chrome.runtime.lastError;
     }
@@ -215,6 +215,9 @@ async function setDecoyMode(enabled) {
 
   if (enabled) {
     await clearBlockedCounts();
+  } else {
+    const tabStats = await getAllTabStats();
+    await syncAllTabBadges(tabStats, false);
   }
 
   return {
@@ -253,11 +256,6 @@ function countTrackingParams(rawUrl) {
   }
 }
 
-function parseDnrActionCount(badgeText) {
-  const match = String(badgeText || "").match(/\d+/);
-  return match ? Number(match[0]) : 0;
-}
-
 async function getAllTabStats() {
   const result = await storageGet(TAB_STATS_KEY);
   return result[TAB_STATS_KEY] || {};
@@ -267,6 +265,29 @@ async function setAllTabStats(tabStats) {
   await storageSet({
     [TAB_STATS_KEY]: tabStats
   });
+}
+
+function getActiveBadgeCount(stats, decoyMode) {
+  const count = decoyMode ? stats.decoyedRequests : stats.blockedOnPage;
+  return Math.max(0, Number(count) || 0);
+}
+
+async function syncBadgeForTab(tabId, stats, decoyMode = null) {
+  if (!Number.isInteger(tabId) || tabId < 0) {
+    return;
+  }
+
+  const mode = decoyMode === null ? await getDecoyMode() : decoyMode;
+  const count = getActiveBadgeCount(normalizeTabStats(stats), mode);
+  await setBadgeText(tabId, count > 0 ? String(count) : "");
+}
+
+async function syncAllTabBadges(tabStats, decoyMode = null) {
+  await Promise.all(
+    Object.entries(tabStats).map(([tabId, stats]) => {
+      return syncBadgeForTab(Number(tabId), stats, decoyMode);
+    })
+  );
 }
 
 async function clearBlockedCounts() {
@@ -285,6 +306,7 @@ async function clearBlockedCounts() {
     })
   );
   await setAllTabStats(nextStats);
+  await syncAllTabBadges(nextStats, true);
 }
 
 async function getTabStats(tabId) {
@@ -309,6 +331,7 @@ async function updateTabStats(tabId, updater) {
     ...tabStats,
     [String(tabId)]: next
   });
+  await syncBadgeForTab(tabId, next);
 
   return next;
 }
@@ -320,14 +343,17 @@ async function resetTabStats(tabId, initialStats = {}) {
 
   const tabStats = await getAllTabStats();
 
+  const next = normalizeTabStats({
+    ...createEmptyTabStats(),
+    ...initialStats,
+    updatedAt: Date.now()
+  });
+
   await setAllTabStats({
     ...tabStats,
-    [String(tabId)]: normalizeTabStats({
-      ...createEmptyTabStats(),
-      ...initialStats,
-      updatedAt: Date.now()
-    })
+    [String(tabId)]: next
   });
+  await syncBadgeForTab(tabId, next);
 }
 
 async function setPendingNavigation(tabId, trackingParamCount) {
@@ -404,18 +430,6 @@ async function syncBlockedEstimateForTab(tabId, estimate) {
   }));
 }
 
-async function syncDnrActionCountForTab(tabId) {
-  const badgeText = await getBadgeText(tabId);
-  const actionCount = parseDnrActionCount(badgeText);
-  const current = await getTabStats(tabId);
-  const estimatedBlockCount = Math.max(
-    0,
-    actionCount - current.trackingLinksCleaned
-  );
-
-  return syncBlockedEstimateForTab(tabId, estimatedBlockCount);
-}
-
 async function updatePageSignals(tabId, signals) {
   const detectedCategories = Array.isArray(signals.detectedCategories)
     ? signals.detectedCategories.filter((category) => {
@@ -470,17 +484,14 @@ async function recordDecoyedRequest(tabId, hostname) {
 async function getReport(tabId) {
   await updateQueue;
   const decoyMode = await getDecoyMode();
-  if (!decoyMode) {
-    await syncDnrActionCountForTab(tabId);
-  }
-
   const pageStats = await getTabStats(tabId);
+  await syncBadgeForTab(tabId, pageStats, decoyMode);
 
   return {
     page: pageStats,
     decoyMode,
     localOnly: true,
-    counterMode: "production_estimate"
+    counterMode: "local_estimate"
   };
 }
 
@@ -548,7 +559,7 @@ chrome.runtime.onInstalled.addListener(() => {
     await clearTransientLocalData();
     await syncDecoyRuleStateFromStorage();
   });
-  setDnrActionBadgeEnabled();
+  configureActionBadge();
 });
 
 chrome.runtime.onStartup.addListener(() => {
@@ -556,7 +567,7 @@ chrome.runtime.onStartup.addListener(() => {
     await clearTransientLocalData();
     await syncDecoyRuleStateFromStorage();
   });
-  setDnrActionBadgeEnabled();
+  configureActionBadge();
 });
 
 chrome.webNavigation.onBeforeNavigate.addListener((details) => {
@@ -593,3 +604,5 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 });
 
 chrome.runtime.onMessage.addListener(handleMessage);
+
+configureActionBadge();

--- a/scripts/browser-test.mjs
+++ b/scripts/browser-test.mjs
@@ -8,7 +8,7 @@
  *   1. Tracking URL parameters are removed from the final page URL by the
  *      extension's declarativeNetRequest redirect rules.
  *   2. The extension background service worker returns a report with
- *      reasonable (nonzero total activity) values.
+ *      reasonable (nonzero total activity) values and a matching badge.
  *   3. The popup exposes an experimental Decoy Mode toggle and privacy warning.
  *   4. Decoy Mode keeps URL cleanup on, disables only tracker blocking, reuses
  *      one session profile, counts modified requests, and avoids false blocks.
@@ -723,6 +723,15 @@ async function main() {
           totalActivity > 0,
           `totalActivity=${totalActivity}, page=${JSON.stringify(page)}`
         );
+
+        const normalBadgeText = await evaluateExtension(`
+          chrome.action.getBadgeText({ tabId: ${JSON.stringify(tabId)} })
+        `);
+        check(
+          "Background report: badge matches blocked estimate",
+          normalBadgeText === String(page.blockedOnPage || ""),
+          `badge=${JSON.stringify(normalBadgeText)}, blocked=${page.blockedOnPage}`
+        );
       } else {
         check("Background report: valid response", false, JSON.stringify(report));
       }
@@ -804,6 +813,15 @@ async function main() {
           decoyReport?.report?.page?.decoyedRequests > 0 &&
           decoyReport?.report?.page?.blockedOnPage === 0,
         JSON.stringify(decoyReport)
+      );
+      const decoyBadgeText = await evaluateExtension(`
+        chrome.action.getBadgeText({ tabId: ${JSON.stringify(tabId)} })
+      `);
+      check(
+        "Decoy Mode: badge matches decoyed request count",
+        decoyBadgeText ===
+          String(decoyReport?.report?.page?.decoyedRequests || ""),
+        `badge=${JSON.stringify(decoyBadgeText)}, report=${JSON.stringify(decoyReport)}`
       );
 
       const disabledPopup = await evaluatePopup(`


### PR DESCRIPTION
## Summary

- replace Chrome's unreadable automatic DNR badge with a production-safe extension-owned badge
- mirror the popup's active metric: estimated blocks in normal mode and decoyed requests in Decoy Mode
- synchronize badge state on navigation, report updates, and mode changes
- document the counter behavior and add real-browser regression coverage

## Root cause

Chrome displays the automatic declarativeNetRequest action count, but `chrome.action.getBadgeText()` returns only a placeholder unless the extension requests `declarativeNetRequestFeedback`. GetBlocked! intentionally forbids that debug-sensitive permission, so the popup could not recover the number shown on the badge.

## Validation

- `npm run check`
- `npm run test:browser` — 17 passed
- `git diff --check`

Closes #10
