### PR TITLE
Clarify the page tracker estimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is built as a small, inspectable Manifest V3 project for people who want a fr
 - Cleans common tracking URL parameters such as `utm_source`, `fbclid`, `gclid`, `dclid`, `mc_cid`, and similar campaign IDs.
 - Detects visible tracking attempts such as pixels, suspicious scripts, tracking iframes, and tracking links.
 - Shows a compact popup report with:
-  - Blocked on this page
+  - Estimated tracker resources on this page
   - Decoyed on this page
   - Tracking links cleaned
   - Visible tracking attempts detected
@@ -113,7 +113,7 @@ There are no extension-owned analytics, telemetry endpoints, remote logs, or bun
 5. Select the GetBlocked! project folder.
 6. Pin GetBlocked! and open the popup on normal web pages.
 
-The production build avoids debug-only DNR feedback permissions. The popup uses local page signals for a page-level estimate, and the extension badge mirrors **Blocked on this page** in normal mode or **Decoyed on this page** in Decoy Mode. URL-cleaning activity is reported separately. In normal mode, blocking and URL cleanup are enforced by MV3 `declarativeNetRequest`; in Decoy Mode, only the blocking rule is disabled.
+The production build avoids debug-only DNR feedback permissions. In normal mode, the popup and badge report an **Estimated tracker resources on this page** count derived from unique known-tracker resource URLs detected locally in the page. This is an estimate of tracker resources targeted by the blocking rules, not a Chrome-confirmed count of matched or blocked network requests. In Decoy Mode, the badge instead mirrors **Decoyed on this page**, which counts supported request payloads actually modified by the extension. URL-cleaning activity is reported separately. Normal-mode blocking and URL cleanup are enforced by MV3 `declarativeNetRequest`; in Decoy Mode, only the blocking rule is disabled.
 
 ## Contribute In 10 Minutes
 

--- a/background.js
+++ b/background.js
@@ -107,6 +107,20 @@ function setBadgeText(tabId, text) {
   });
 }
 
+function setActionTitle(tabId, title) {
+  return new Promise((resolve) => {
+    if (!Number.isInteger(tabId) || tabId < 0) {
+      resolve();
+      return;
+    }
+
+    chrome.action.setTitle({ tabId, title }, () => {
+      void chrome.runtime.lastError;
+      resolve();
+    });
+  });
+}
+
 function configureActionBadge() {
   chrome.action.setBadgeBackgroundColor({ color: "#0f766e" });
 
@@ -279,7 +293,14 @@ async function syncBadgeForTab(tabId, stats, decoyMode = null) {
 
   const mode = decoyMode === null ? await getDecoyMode() : decoyMode;
   const count = getActiveBadgeCount(normalizeTabStats(stats), mode);
-  await setBadgeText(tabId, count > 0 ? String(count) : "");
+  const title = mode
+    ? `Decoyed requests on this page: ${count}`
+    : `Estimated tracker resources on this page: ${count}`;
+
+  await Promise.all([
+    setBadgeText(tabId, count > 0 ? String(count) : ""),
+    setActionTitle(tabId, title)
+  ]);
 }
 
 async function syncAllTabBadges(tabStats, decoyMode = null) {

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -121,13 +121,15 @@ Rules stay limited to `domainType: "thirdParty"` to reduce website breakage.
 
 The popup requests a local report from the background service worker. It shows:
 
-- Blocked on this page
+- Estimated tracker resources on this page
 - Decoyed on this page
 - Tracking links cleaned
 - Visible tracking attempts detected
 - Detected categories
 
 It does not show a privacy score.
+
+The normal-mode estimate comes from unique resource URLs on known tracker domains that `content-script.js` can observe in the page. It does not claim to be a Chrome-confirmed count of DNR rule matches or blocked network requests. The production extension intentionally avoids the debug-only DNR feedback permission required for exact match reporting. The action badge uses the same estimate and exposes an explicit title; in Decoy Mode it switches to the exact number of supported request payloads modified by the extension.
 
 The popup also owns the **Decoy Mode (Experimental)** toggle. It asks the service worker to update the static-rule state before the saved setting changes, then refreshes the report. When the mode is on, the footer warns that tracker requests may still reveal IP and network metadata.
 

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -38,7 +38,7 @@
 
       <section class="stats" aria-label="Tracker statistics">
         <div class="stat">
-          <span class="stat-label">Blocked on this page</span>
+          <span class="stat-label">Estimated tracker resources on this page</span>
           <strong id="page-blocked">0</strong>
         </div>
         <div class="stat">

--- a/scripts/browser-test.mjs
+++ b/scripts/browser-test.mjs
@@ -8,7 +8,7 @@
  *   1. Tracking URL parameters are removed from the final page URL by the
  *      extension's declarativeNetRequest redirect rules.
  *   2. The extension background service worker returns a report with
- *      reasonable (nonzero total activity) values and a matching badge.
+ *      reasonable (nonzero total activity) values and a clearly labeled badge.
  *   3. The popup exposes an experimental Decoy Mode toggle and privacy warning.
  *   4. Decoy Mode keeps URL cleanup on, disables only tracker blocking, reuses
  *      one session profile, counts modified requests, and avoids false blocks.
@@ -674,12 +674,20 @@ async function main() {
       const initialPopup = await evaluatePopup(`({
         checked: document.querySelector("#decoy-mode-toggle")?.checked,
         experimental:
-          document.querySelector(".experimental-badge")?.textContent?.trim()
+          document.querySelector(".experimental-badge")?.textContent?.trim(),
+        estimateLabel:
+          document.querySelector("#page-blocked")?.previousElementSibling?.textContent?.trim()
       })`);
       check(
         "Popup: experimental Decoy Mode toggle is present and off by default",
         initialPopup?.checked === false &&
           initialPopup?.experimental === "Experimental",
+        JSON.stringify(initialPopup)
+      );
+      check(
+        "Popup: normal-mode count is labeled as an estimate",
+        initialPopup?.estimateLabel ===
+          "Estimated tracker resources on this page",
         JSON.stringify(initialPopup)
       );
 
@@ -727,10 +735,19 @@ async function main() {
         const normalBadgeText = await evaluateExtension(`
           chrome.action.getBadgeText({ tabId: ${JSON.stringify(tabId)} })
         `);
+        const normalActionTitle = await evaluateExtension(`
+          chrome.action.getTitle({ tabId: ${JSON.stringify(tabId)} })
+        `);
         check(
           "Background report: badge matches blocked estimate",
           normalBadgeText === String(page.blockedOnPage || ""),
           `badge=${JSON.stringify(normalBadgeText)}, blocked=${page.blockedOnPage}`
+        );
+        check(
+          "Background report: badge title identifies the estimated count",
+          normalActionTitle ===
+            `Estimated tracker resources on this page: ${page.blockedOnPage || 0}`,
+          `title=${JSON.stringify(normalActionTitle)}, blocked=${page.blockedOnPage}`
         );
       } else {
         check("Background report: valid response", false, JSON.stringify(report));
@@ -817,11 +834,20 @@ async function main() {
       const decoyBadgeText = await evaluateExtension(`
         chrome.action.getBadgeText({ tabId: ${JSON.stringify(tabId)} })
       `);
+      const decoyActionTitle = await evaluateExtension(`
+        chrome.action.getTitle({ tabId: ${JSON.stringify(tabId)} })
+      `);
       check(
         "Decoy Mode: badge matches decoyed request count",
         decoyBadgeText ===
           String(decoyReport?.report?.page?.decoyedRequests || ""),
         `badge=${JSON.stringify(decoyBadgeText)}, report=${JSON.stringify(decoyReport)}`
+      );
+      check(
+        "Decoy Mode: badge title identifies the decoyed request count",
+        decoyActionTitle ===
+          `Decoyed requests on this page: ${decoyReport?.report?.page?.decoyedRequests || 0}`,
+        `title=${JSON.stringify(decoyActionTitle)}, report=${JSON.stringify(decoyReport)}`
       );
 
       const disabledPopup = await evaluatePopup(`


### PR DESCRIPTION
## Summary

- relabel the normal-mode popup count as an estimate of tracker resources detected on the page
- add an accessible action title that distinguishes the normal estimate from Decoy Mode's modified-request count
- document the estimate's local DOM/resource source and its DNR match-count limitation
- extend the browser harness to cover the popup label and both badge-title modes

No manifest permissions, DNR rules, remote behavior, telemetry, storage model, or Decoy Mode behavior changed.

## Testing

- `npm run check`
- focused service-worker mock for normal and Decoy badge text/title behavior
- `npm run test:browser` attempted; the local Chrome 152 build did not load the unpacked extension, so the repository harness reported its documented skip rather than a browser pass

Closes #16.

AI assistance: OpenAI Codex assisted with implementation and test preparation; the final diff and validation results were reviewed locally.